### PR TITLE
RHEL RPM .spec file and init script.

### DIFF
--- a/contrib/mangodb.init
+++ b/contrib/mangodb.init
@@ -32,7 +32,7 @@ start() {
 
 stop() {
   echo "Shutting down $desc: "
-  pkill -f MangoDB
+  pkill -f mangodb
 }
 
 restart() {
@@ -41,7 +41,7 @@ restart() {
 }
 
 status() {
-  pid=$(pgrep -f MangoDB)
+  pid=$(pgrep -f mangodb)
 
   if [ -z $pid ]; then
     echo "MangoDB is NOT running."

--- a/contrib/mangodb.spec
+++ b/contrib/mangodb.spec
@@ -80,8 +80,6 @@ chkconfig --add %{name}
 %preun 
 service %{name} stop >/dev/null 2>&1
 chkconfig --del %{name}
-%postun
-service %{name} condrestart >/dev/null 2>&1
 
 %changelog
 * Wed Jun 20 2012 Nathan Milford <nathan@milford.io> - 0.0.1


### PR DESCRIPTION
Build yourself some Python 2.7 RPMS thus: 
http://blog.milford.io/2012/01/building-and-installing-python-2-7-rpms-on-centos-5-7/

Install gevent like this:
`curl http://pypi.python.org/packages/source/g/gevent/gevent-0.13.7.tar.gz | tar zxv
cd gevent-0.13.7
python2.7 ./setup.py build
sudo python2.7 ./setup.py install`

Setup your RPM build environment:
`sudo yum -y install rpmdevtools && rpmdev-setuptree`

Grab the MangoDB tarball thus:
`wget http://nodeload.github.com/dcramer/mangodb/tarball/master \
-O ~/rpmbuild/SOURCES/mangodb-0.0.1.tar.gz`

Also drop the `mangodb.init` file in `~/rpmbuild/SOURCES/`.

Drop the `mangodb.spec` file in `~/rpmbuild/SPECS/`.

Build it:
`rpmbuild -bb ./SPECS/mangodb.spec`

Install it:
`sudo rpm -Uvh ~/rpmbuild/RPMS/noarch/mangodb-0.0.1-1.noarch.rpm`

Fire it up:
`/etc/init.d/mangodb start`
