### PR TITLE
Optimize concurrent access

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,11 +1,13 @@
 from gevent.server import StreamServer
 import os
+import threading
 
 
 def mangodb(socket, address):
     socket.sendall('HELLO\r\n')
     client = socket.makefile()
     output = open('/dev/null', 'w')
+    lock = threading.Lock()
     while 1:
         line = client.readline()
         if not line:
@@ -15,10 +17,12 @@ def mangodb(socket, address):
         if cmd == 'BYE':
             break
         if len(cmd_bits) > 1:
+            lock.acquire(True)
             output.write(cmd_bits[1])
             if os.environ.get('MANGODB_DURABLE', False):
                 output.flush()
                 os.fsync(output.fileno())
+            lock.release()
             client.write('OK' + os.urandom(1024).encode('string-escape') + '\r\n')
         client.flush()
 


### PR DESCRIPTION
We had a production issue with Mango, that lead us to find this fairly subtle corner case. It is possible for two users to come to our site _at the same time_ resulting in multiple concurrent requests to Mango. This leads to performance problems due to context switching. Python tries to optimize this (see, e.g., http://www.dabeaz.com/python/UnderstandingGIL.pdf ), but in a distributed system I don't think we can assume that all nodes are implemented in python. This patch fixes the problem.
