### PR TITLE
MangoDB is not cross-platform

### DIFF
--- a/server.py
+++ b/server.py
@@ -6,7 +6,7 @@ import threading
 def mangodb(socket, address):
     socket.sendall('HELLO\r\n')
     client = socket.makefile()
-    output = open('/dev/null', 'w')
+    output = open(os.devnull, 'w')
     lock = threading.Lock()
     while 1:
         line = client.readline()


### PR DESCRIPTION
It is important that platforms such as Windows can benefit from powerful web-scale persistance mechanisms like MangoDB.

MangoDB currently relies on a platform-specific path to implement its off-disk spooling mechanism. I've adapted it to support the relevant path on any platform where Python runs.
