### PR TITLE
use INADDR_ANY for increased portability

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,5 +1,7 @@
 from gevent.server import StreamServer
 import os
+import socket
+import struct
 import threading
 
 
@@ -38,6 +40,8 @@ def mangodb(socket, address):
 
 
 if __name__ == '__main__':
-    server = StreamServer(('0.0.0.0', 27017), mangodb)
+    packed_addr = struct.pack('!L', socket.INADDR_ANY)
+    iface = socket.inet_ntoa(packed_addr)
+    server = StreamServer((iface, 27017), mangodb)
     print ('Starting MangoDB on port 27017')
     server.serve_forever()


### PR DESCRIPTION
I believe that there is a subtle portability problem in the current implementation. We would like to bind to any (i.e. all) network interfaces to ensure that all processes can reach Mango, whether they exist on localhost or are external. The correct way to do this is to use the system-defined value for `INADDR_ANY`.<sup>[1](#myfootnote1)</sup> However, the current implementation assumes that this will be '0.0.0.0'. While it is certainly true that many operating systems implement `INADDR_ANY` in this way, I'm worried that Mango could break in unforeseen ways on new and alternative TCP/IP stacks provided by next-generation cloud operating systems. This change should ensure the longevity of Mango by increasing the likelihood that it will be able to correctly adapt in these situations.

<a name="myfootnote1">1</a>: See http://pubs.opengroup.org/onlinepubs/000095399/basedefs/netinet/in.h.html for details.